### PR TITLE
Fix: variable name should be lower case to match assignment

### DIFF
--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -344,7 +344,7 @@ each line.
 
 ```python
 dict_file = open(DICT, "r")
-for line in DICT_FILE:
+for line in dict_file:
     print(line)
 ```
 


### PR DESCRIPTION
Example code does not run due to mis-matching uppercase variable access.